### PR TITLE
Smart boundary printing, Makefile overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 *.out
 *.d
 
-bin/*
+fetcha
 config.h

--- a/fetcha.c
+++ b/fetcha.c
@@ -450,7 +450,7 @@ print_fetch(struct ascii *res)
         exit(EXIT_FAILURE);
       } 
       goto print_fetch_end;
-    } else if (header_len > 0) {
+    } else if (header_len > 0 && strlen(boundary_char) > 0) {
       print_boundary(boundary_char, header_len);  
       header_len = -1;
       goto print_fetch_end;


### PR DESCRIPTION
- The boundary only gets printed if `boundary_char` is a non-empty string
- This Makefile is derived from dwm's. You may see a compile warning that wasn't there before; this is because you used `$(CFLAGS)` under the binary build rule, but named the variable `CCFLAGS`.