### PR TITLE
Add Editor module using $EDITOR

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -59,6 +59,7 @@ static info_item config_items[] = {
   { "GPU",      get_gpus },
   { "WM",       get_wm },
   { "Shell",    get_shell },
+  { "Editor",   get_editor },
   { "Terminal", get_terminal },
 
 };

--- a/modules.c
+++ b/modules.c
@@ -512,5 +512,15 @@ get_terminal(void)
     }
 
     return strdup("unknown");
+}
 
+char *
+get_editor(void)
+{
+  char *editor = getenv("EDITOR");
+  if (editor && *editor) {
+    return strdup(editor);
+  }
+
+  return strdup("unknown");
 }

--- a/modules.h
+++ b/modules.h
@@ -21,6 +21,7 @@ char *get_gpus(void);
 char *get_wm(void);
 char *get_shell(void);
 char *get_terminal(void);
+char *get_editor(void);
 
 
 #endif


### PR DESCRIPTION
This PR adds a small Editor module that reports the $EDITOR environment
variable, similar to the existing Shell and Terminal modules.

The module returns an allocated char * and follows the existing module
conventions. It is enabled in the default configuration.

If $EDITOR is not set, the module returns "unknown".
