### PR TITLE
Fix invalid pointer segfault

### DIFF
--- a/modules.c
+++ b/modules.c
@@ -70,7 +70,7 @@ get_os(void)
 
   size_t len = strlen(osname) + strlen(buf.machine) + 2;
   char *out = malloc(len);
-  if (!*out) return NULL;
+  if (!out) return NULL;
 
   snprintf(out, len, "%s %s", osname, buf.machine);
 


### PR DESCRIPTION
Around 2 weeks ago I updated my Arch Linux system and noticed fetcha was segfaulting with the message
```
free(): invalid pointer
Aborted                    (core dumped) fetcha
```

This single dereference turned out to be the cause, or at the very least, it allowed me to get back to a working fetcha